### PR TITLE
Add export feature and fix Profile layout behavior

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,10 +15,8 @@
         <activity android:name=".activities.RemindersList" />
         <activity android:name=".activities.PetProfile" />
         <activity android:name=".activities.HomePage">
-
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/res/layout/pet_profile.xml
+++ b/app/src/main/res/layout/pet_profile.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:fab="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:fab="http://schemas.android.com/apk/res-auto"
     tools:context=".activities.PetProfile">
+    
 
     <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.0"
@@ -19,11 +22,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="60dp"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:paddingBottom="120dp">
 
             <ImageView
                 android:id="@+id/petPicture"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:src="@mipmap/ic_launcher"
@@ -42,11 +48,13 @@
                     android:layout_marginStart="130dp"
                     android:layout_weight="1"
                     android:text="@string/change_picture" />
+
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+
                 android:orientation="horizontal">
 
                 <TextView
@@ -69,13 +77,13 @@
                 android:layout_height="200dp"
                 android:ems="10"
                 android:hint="@string/pet_description"
-                android:inputType="textMultiLine"
+                android:inputType="textMultiLine|textCapSentences"
                 tools:layout_conversion_absoluteHeight="200dp"
                 tools:layout_conversion_absoluteWidth="411dp" />
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
                 <TextView
@@ -95,7 +103,7 @@
                     android:layout_gravity="end"
                     android:ems="10"
                     android:hint="@string/care_instructions"
-                    android:inputType="textMultiLine" />
+                    android:inputType="textMultiLine|textCapSentences" />
             </LinearLayout>
 
             <LinearLayout
@@ -120,12 +128,12 @@
                     android:layout_gravity="end"
                     android:ems="10"
                     android:hint="@string/medical_info"
-                    android:inputType="textMultiLine" />
+                    android:inputType="textMultiLine|textCapSentences" />
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:orientation="horizontal">
 
                 <TextView
@@ -145,7 +153,7 @@
                     android:layout_gravity="end"
                     android:ems="10"
                     android:hint="@string/preferred_vet"
-                    android:inputType="textMultiLine" />
+                    android:inputType="textMultiLine|textCapSentences" />
             </LinearLayout>
 
             <LinearLayout
@@ -171,10 +179,9 @@
                     android:ems="10"
                     android:gravity="center_vertical"
                     android:hint="@string/emergency_contact_info"
-                    android:inputType="textMultiLine" />
+                    android:inputType="textMultiLine|textCapSentences" />
 
             </LinearLayout>
-
         </LinearLayout>
     </ScrollView>
 
@@ -186,27 +193,18 @@
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintVertical_bias="1.0" />
 
     <com.github.clans.fab.FloatingActionMenu
 
         android:id="@+id/fab_menu"
-        android:layout_width="164dp"
-        android:layout_height="313dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="292dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.973"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/include"
-        app:layout_constraintVertical_bias="0.495"
+        android:paddingTop="50dp"
         fab:menu_animationDelayPerItem="50"
-        fab:menu_backgroundColor="@android:color/transparent"
+        fab:menu_backgroundColor="#80000000"
         fab:menu_buttonSpacing="0dp"
         fab:menu_colorNormal="#DA4336"
         fab:menu_colorPressed="#E75043"


### PR DESCRIPTION
We now have support for exporting through an implicit intent that parses
the text on the profile page and passes the fields into a template.

Scrolling behavior for the profile page works a little more cleanly now.

The FAB menu is now fixed in a better location, makes the background
opaque when active, hides the text cursor when active, and restores the
text cursor when closed.