### PR TITLE
Update behavior for navigating between pages.

### DIFF
--- a/app/src/main/java/com/pawstime/ImageSaver.java
+++ b/app/src/main/java/com/pawstime/ImageSaver.java
@@ -49,7 +49,7 @@ public class ImageSaver {
 
     //Create unique image file name
     public ImageSaver setFileName() {
-        this.fileName =  Pet.getCurrentPetName() + ".png";
+        this.fileName =  Pet.getCurrentPet() + ".png";
         return this;
     }
 

--- a/app/src/main/java/com/pawstime/Pet.java
+++ b/app/src/main/java/com/pawstime/Pet.java
@@ -2,22 +2,12 @@ package com.pawstime;
 
 public class Pet {
 
-    private static String currentPetName;
-    private static String currentPetType;
+    private static String currentPet;
 
-    public static void setCurrentPetName(String name) {
-        currentPetName = name;
+    public static void setCurrentPet(String pet) {
+        currentPet = pet;
     }
-    public static String getCurrentPetName() {
-        return currentPetName;
+    public static String getCurrentPet() {
+        return currentPet;
     }
-
-    public static void setCurrentPetType(String type) {
-        currentPetType = type;
-    }
-
-    public static String getCurrentPetType() {
-        return currentPetType;
-    }
-
 }

--- a/app/src/main/java/com/pawstime/PetCard.java
+++ b/app/src/main/java/com/pawstime/PetCard.java
@@ -2,22 +2,41 @@ package com.pawstime;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.constraint.ConstraintLayout;
 import android.support.v7.widget.CardView;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.pawstime.activities.HomePage;
+
 public class PetCard extends CardView {
     public TextView name;
+    public ConstraintLayout layout;
+    public CardView petCardView;
     public ImageView picture;
     public PetCard(@NonNull Context context) {
         super(context);
         inflate(getContext(), R.layout.pet_card_layout, this);
         name = findViewById(R.id.petCardName);
+        layout = findViewById(R.id.petCardLayout);
+        petCardView = findViewById(R.id.petCardCard);
+        picture = findViewById(R.id.petCardPicture);
+
+
+        petCardView.setOnClickListener(v -> click(context));
+        picture.setOnClickListener(v -> click(context));
+        name.setOnClickListener(v -> click(context));
     }
 
     public void setName(String newName) {
         name.setText(newName);
     }
 
-//    public void setPicture() {}
+    public String getName() {
+        return name.getText().toString();
+    }
+
+    public void click(Context context) {
+        HomePage.clickPetCard(getName(), context);
+    }
 }

--- a/app/src/main/java/com/pawstime/activities/HomePage.java
+++ b/app/src/main/java/com/pawstime/activities/HomePage.java
@@ -1,6 +1,6 @@
 package com.pawstime.activities;
 
-import android.content.Intent;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 
@@ -25,16 +25,16 @@ public class HomePage extends BaseActivity implements AddPet.AddPetDialogListene
 
     @Override
     public void onAddPetDialogPositiveClick(DialogFragment dialog) {
-            Intent i = new Intent(this, PetProfile.class);
-            startActivity(i);
-            finish();
+        startProfileActivity(this);
     }
 
     @Override
     public void onAddPetDialogNegativeClick(DialogFragment dialog) {}
 
     @Override
-    public void onSelectPetDialogPositiveClick(DialogFragment dialog) {}
+    public void onSelectPetDialogPositiveClick(DialogFragment dialog) {
+        startProfileActivity(this);
+    }
     @Override
     public void onSelectPetDialogNegativeClick(DialogFragment dialog) {}
     @Override
@@ -68,15 +68,14 @@ public class HomePage extends BaseActivity implements AddPet.AddPetDialogListene
     }
 
     private void checkForPets() {
-        String currentPetName = Pet.getCurrentPetName();
-        String currentPetType = Pet.getCurrentPetType();
+        String currentPet = Pet.getCurrentPet();
 
         // Check if the profile file exists
         File directory = getApplicationContext().getFilesDir();
         File profile = new File(directory, "profile");
-        if (currentPetName == null && currentPetType == null) {
+        if (currentPet == null) {
             if (profile.exists()) {
-                openSelectPetDialog();
+                Pet.setCurrentPet(getPetsList(this).get(0));
             } else {
                 openAddPetDialog();
             }
@@ -93,14 +92,17 @@ public class HomePage extends BaseActivity implements AddPet.AddPetDialogListene
         LinearLayout petList = findViewById(R.id.petList);
 
         ArrayList<String> listOfPets = getPetsList(this);
-
         for (int i = 0; i < listOfPets.size(); i++) {
             PetCard cardView = new PetCard(this);
             cardView.setName(listOfPets.get(i));
 //            cardView.setPicture();
             petList.addView(cardView);
         }
+    }
 
+    public static void clickPetCard(String name, Context context) {
+        Pet.setCurrentPet(name);
+        startProfileActivity(context);
     }
 }
 

--- a/app/src/main/java/com/pawstime/dialogs/AddPet.java
+++ b/app/src/main/java/com/pawstime/dialogs/AddPet.java
@@ -19,11 +19,9 @@ import com.pawstime.activities.BaseActivity;
 
 import org.json.JSONObject;
 
-import java.io.BufferedReader;
 
 import java.io.FileOutputStream;
 import java.io.File;
-import java.io.FileReader;
 import java.util.ArrayList;
 
 public class AddPet extends DialogFragment{
@@ -35,7 +33,6 @@ public class AddPet extends DialogFragment{
     public interface AddPetDialogListener {
         void onAddPetDialogPositiveClick(DialogFragment dialog);
         void onAddPetDialogNegativeClick(DialogFragment dialog);
-
     }
 
     // Use this instance of the interface to deliver action events
@@ -80,7 +77,9 @@ public class AddPet extends DialogFragment{
             Button positive = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
             positive.setOnClickListener(v -> {
                 if (name.getText().toString().length() > 0 && type.getText().toString().length() > 0) {
-                    if (save(name.getText().toString(), type.getText().toString(), rootView.getContext())) {
+                    String newPet = name.getText().toString() + " the " + type.getText().toString();
+
+                    if (save(newPet, rootView.getContext())) {
                         listener.onAddPetDialogPositiveClick(AddPet.this); // Put the listener right where we want the actions to be occurring
                     }
                 } else {
@@ -91,7 +90,7 @@ public class AddPet extends DialogFragment{
         return dialog;
     }
 
-    public boolean save(String name, String type, Context context) {
+    public boolean save(String newPet, Context context) {
         FileOutputStream outputStream;
         File directory = context.getFilesDir();
         File profile = new File(directory, "profile");
@@ -107,14 +106,13 @@ public class AddPet extends DialogFragment{
         }
 
     // If pet is a new pet
-        if (!petList.contains(name)) {
+        if (!petList.contains(newPet)) {
             ArrayMap<String, String> map = new ArrayMap<>();
-            map.put("name", name);
-            map.put("type", type);
+            map.put("nameAndType", newPet);
             JSONObject json = new JSONObject(map);
 
             try {
-                outputStream = context.openFileOutput(name, Context.MODE_PRIVATE);
+                outputStream = context.openFileOutput(newPet, Context.MODE_PRIVATE);
                 outputStream.write(json.toString().getBytes());
                 outputStream.close(); // Don't forget to close the stream!
                 Toast.makeText(context, "Pet successfully added!", Toast.LENGTH_SHORT).show();
@@ -132,10 +130,9 @@ public class AddPet extends DialogFragment{
 
                     outputStream = context.openFileOutput("profile", Context.MODE_PRIVATE);
                     outputStream.write(petsToWrite.getBytes()); // Write previous pets
-                    outputStream.write((name + ",").getBytes()); // Append new pet's name and a separator (comma)
+                    outputStream.write((newPet + ",").getBytes()); // Append new pet's name and a separator (comma)
                     outputStream.close();
-                    Pet.setCurrentPetName(name);
-                    Pet.setCurrentPetType(type);
+                    Pet.setCurrentPet(newPet);
                     return true;
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/app/src/main/java/com/pawstime/dialogs/SelectPet.java
+++ b/app/src/main/java/com/pawstime/dialogs/SelectPet.java
@@ -82,7 +82,7 @@ public class SelectPet extends DialogFragment {
     }
 
     void addPets(ArrayList<String> listOfPets, Context context) {
-        String currentPet = Pet.getCurrentPetName();
+        String currentPet = Pet.getCurrentPet();
         for (int i = 0; i < listOfPets.size(); i++) {
             RadioButton rb = new RadioButton(context);
             rb.setId(i);
@@ -98,7 +98,7 @@ public class SelectPet extends DialogFragment {
         if(radioGroup.getCheckedRadioButtonId() != -1) {
             int selectedId = radioGroup.getCheckedRadioButtonId();
             RadioButton selectedPet = rootView.findViewById(selectedId);
-            Pet.setCurrentPetName(selectedPet.getText().toString());
+            Pet.setCurrentPet(selectedPet.getText().toString());
             return true;
         }
         return false;

--- a/app/src/main/java/com/pawstime/dialogs/UnsavedChangesDialog.java
+++ b/app/src/main/java/com/pawstime/dialogs/UnsavedChangesDialog.java
@@ -1,0 +1,76 @@
+package com.pawstime.dialogs;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+import android.widget.Button;
+
+import com.pawstime.activities.BaseActivity;
+
+
+public class UnsavedChangesDialog extends DialogFragment {
+    public LayoutInflater inflater;
+
+    public interface UnsavedChangesDialogListener {
+        void onUnsavedChangesDialogPositiveClick(DialogFragment dialog);
+        void onUnsavedChangesDialogNegativeClick(DialogFragment dialog);
+        void onUnsavedChangesDialogNeutralClick(DialogFragment dialog);
+    }
+
+//    // Use this instance of the interface to deliver action events
+    UnsavedChangesDialogListener listener;
+
+    // Override the Fragment.onAttach() method to instantiate the listener
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        // Verify that the host activity implements the callback interface
+        try {
+            // Instantiate the SelectPetDialogListener so we can send events to the host
+            listener = (UnsavedChangesDialogListener) context;
+        } catch (ClassCastException e) {
+            // The activity doesn't implement the interface, throw exception
+            throw new ClassCastException("Activity must implement AddPetDialogListener");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        inflater = requireActivity().getLayoutInflater();
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+
+        builder.setMessage("You have unsaved changes. Do you want to discard them?");
+        builder.setPositiveButton("Save", (dialog, which) -> {});
+        builder.setNeutralButton("Cancel", (dialog, which) -> {});
+        builder.setNegativeButton("Discard", (dialog, which) -> {});
+
+        AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(dialog1 -> {
+            Button positive = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+            positive.setOnClickListener(v -> {
+                listener.onUnsavedChangesDialogPositiveClick(UnsavedChangesDialog.this);
+                dismiss();
+            });
+
+            Button neutral = dialog.getButton(AlertDialog.BUTTON_NEUTRAL);
+            neutral.setOnClickListener(v -> {
+                listener.onUnsavedChangesDialogNeutralClick(UnsavedChangesDialog.this);
+                dismiss();
+            });
+
+            Button negative = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+            negative.setOnClickListener(v -> {
+                listener.onUnsavedChangesDialogNegativeClick(UnsavedChangesDialog.this);
+                dismiss();
+            });
+
+        });
+       return dialog;
+    }
+}

--- a/app/src/main/res/layout/home_page.xml
+++ b/app/src/main/res/layout/home_page.xml
@@ -6,92 +6,109 @@
     android:layout_height="match_parent"
     tools:context=".activities.HomePage">
 
-    <TextView
-        android:id="@+id/yourPet"
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/your_pets"
-        android:textAlignment="center"
-        app:layout_constraintTop_toBottomOf="@+id/homeLogo" />
-
-    <FrameLayout
-        android:id="@+id/frameLayout"
-        android:layout_width="374dp"
-        android:layout_height="278dp"
-        android:layout_marginTop="8dp"
-        android:background="@android:color/transparent"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/yourPet"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        tools:layout_editor_absoluteX="40dp">
 
-        <android.support.v4.widget.NestedScrollView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginBottom="50dp"
-            android:background="@android:color/transparent"
-            android:fillViewport="true">
+            android:layout_marginTop="60dp"
+            android:orientation="vertical"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:paddingBottom="120dp">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/textView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:layout_gravity="center"
+                android:layout_marginBottom="8dp"
+                android:text="@string/welcome_to_pawstime"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:textSize="30sp"
+                android:textStyle="bold"
+                app:layout_constraintBottom_toBottomOf="@+id/include"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/include"
+                app:layout_constraintVertical_bias="0.12" />
 
-                <LinearLayout
-                    android:id="@+id/petList"
+            <ImageView
+                android:id="@+id/homeLogo"
+                android:layout_width="164dp"
+                android:layout_height="158dp"
+                android:layout_gravity="center"
+                android:layout_marginStart="8dp"
+                android:contentDescription="@string/welcome_to_pawstime"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:src="@tools:sample/avatars"
+                tools:srcCompat="@drawable/ic_paws_time" />
+
+            <TextView
+            android:id="@+id/yourPet"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/your_pets"
+            android:textAlignment="center"
+            app:layout_constraintTop_toBottomOf="@+id/homeLogo" />
+
+            <FrameLayout
+                android:id="@+id/frameLayout"
+                android:layout_width="374dp"
+                android:layout_height="278dp"
+                android:layout_gravity="center"
+                android:layout_marginTop="8dp"
+                android:background="@android:color/transparent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/yourPet"
+                app:layout_constraintVertical_bias="0.0">
+
+                <android.support.v4.widget.NestedScrollView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginBottom="50dp"
                     android:background="@android:color/transparent"
-                    android:orientation="vertical">
+                    android:fillViewport="true">
 
-                </LinearLayout>
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="20dp"
-                    android:background="@android:color/transparent"
-                    android:orientation="vertical" />
+                        <LinearLayout
+                            android:id="@+id/petList"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@android:color/transparent"
+                            android:orientation="vertical" />
 
-            </LinearLayout>
-        </android.support.v4.widget.NestedScrollView>
-
-    </FrameLayout>
-
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:text="@string/welcome_to_pawstime"
-        android:textAlignment="center"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        android:textSize="30sp"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@+id/include"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/include"
-        app:layout_constraintVertical_bias="0.12" />
-
-    <ImageView
-        android:id="@+id/homeLogo"
-        android:layout_width="164dp"
-        android:layout_height="158dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="144dp"
-        android:contentDescription="@string/welcome_to_pawstime"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.481"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:src="@tools:sample/avatars"
-        tools:srcCompat="@drawable/ic_paws_time" />
-
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="20dp"
+                            android:background="@android:color/transparent"
+                            android:orientation="vertical" />
+                    </LinearLayout>
+                </android.support.v4.widget.NestedScrollView>
+            </FrameLayout>
+        </LinearLayout>
+    </ScrollView>
     <include
         android:id="@+id/include"
         layout="@layout/activity_base"
@@ -99,5 +116,4 @@
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/pet_card_layout.xml
+++ b/app/src/main/res/layout/pet_card_layout.xml
@@ -2,30 +2,36 @@
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/constraintLayout"
+    android:id="@+id/petCardLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingTop="1dp"
     android:paddingBottom="1dp"
-    tools:layout_editor_absoluteY="329dp">
+    tools:layout_editor_absoluteY="329dp"
+    android:clickable="true"
+    android:focusable="true">
 
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="horizontal"
-        tools:layout_editor_absoluteY="1dp">
+        tools:layout_editor_absoluteY="1dp"
+        android:clickable="true"
+        android:focusable="true">
 
         <ImageView
-            android:id="@+id/imageView2"
+            android:id="@+id/petCardPicture"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:src="@mipmap/ic_launcher_round"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            android:clickable="true"
+            android:focusable="true"/>
 
         <android.support.v7.widget.CardView
-            android:id="@+id/petCard"
+            android:id="@+id/petCardCard"
             android:layout_width="251dp"
             android:layout_height="56dp"
             app:cardBackgroundColor="@color/design_default_color_primary_dark"
@@ -34,9 +40,11 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.423"
-            app:layout_constraintStart_toEndOf="@+id/imageView2"
+            app:layout_constraintStart_toEndOf="@+id/imageView"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.499">
+            app:layout_constraintVertical_bias="0.499"
+            android:clickable="true"
+            android:focusable="true">
 
             <TextView
                 android:id="@+id/petCardName"
@@ -44,7 +52,9 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:gravity="center"
-                android:textColor="@android:color/white" />
+                android:textColor="@android:color/white"
+                android:clickable="true"
+                android:focusable="true"/>
 
         </android.support.v7.widget.CardView>
     </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/pet_profile.xml
+++ b/app/src/main/res/layout/pet_profile.xml
@@ -26,27 +26,25 @@
             android:focusableInTouchMode="true"
             android:paddingBottom="120dp">
 
-            <ImageView
-                android:id="@+id/petPicture"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:src="@mipmap/ic_launcher"
-                tools:srcCompat="@tools:sample/avatars" />
-
             <LinearLayout
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/petPicture"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:src="@mipmap/ic_launcher"
+                    tools:srcCompat="@tools:sample/avatars" />
 
                 <Button
                     android:id="@+id/changePicture"
-                    android:layout_width="0dp"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:layout_marginStart="130dp"
-                    android:layout_weight="1"
-                    android:text="@string/change_picture"/>
+                    android:text="@string/change_picture" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/reminders_list.xml
+++ b/app/src/main/res/layout/reminders_list.xml
@@ -6,31 +6,22 @@
     android:layout_height="match_parent"
     tools:context=".activities.RemindersList">
 
-    <include
-        android:id="@+id/include"
-        layout="@layout/activity_base"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
-
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/addReminder"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="528dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
         android:clickable="true"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:focusable="true"
+        app:layout_constraintBottom_toBottomOf="@+id/scrollViewReminders"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.976"
+        app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.88"
+        app:layout_constraintVertical_bias="1.0"
         app:srcCompat="@android:drawable/ic_input_add" />
 
     <ScrollView
@@ -47,9 +38,19 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical"></LinearLayout>
+                android:orientation="vertical" />
         </android.support.v7.widget.CardView>
     </ScrollView>
+
+    <include
+        android:id="@+id/include"
+        layout="@layout/activity_base"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0" />
 
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -8,7 +8,7 @@
         android:title="@string/title_home" />
 
     <item
-        android:id="@+id/navigation_viewPets"
+        android:id="@+id/navigation_profile"
         android:icon="@drawable/ic_dashboard_black_24dp"
         android:title="@string/view_profile" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,7 @@
     <string name="pet">Pet</string>
     <string name="alarm_checkbox_text">Alarm</string>
     <string name="welcome_to_pawstime">Welcome to PawsTime</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
When launching the app, the user is no longer prompted to select a pet.
Instead, the first pet is selected by default. The user can also tap on
a card on the home screen to select a pet and immediately navigate to
the corresponding profile.

The cards on the home page now display name "the" type (e.g. Megan the
Poodle). This change resulted in combining the name and type into a
single object saved in the JSON, both for the list of pets and for
individual pet profiles.

Additionally, when leaving the profile page, the app will check for
unsaved changes. The user has the option to either save, discard, or
cancel. This check is also performed when attempting to select a
different pet or a dd a new one.

Improve some general layout formatting.